### PR TITLE
Add some extensibility: configurable cert roots, and not overwriting the hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To schedule a daily task, log into the Synology DSM and add a user-defined scrip
 
 ### Multiple Certificates
 
-If you need to generate more than one certificate with this, you can parameterize synology-letsencrypt.sh with the path of a certificate configuration:
+If you need to generate more than one certificate, you can parameterize synology-letsencrypt.sh with the path of a certificate configuration:
 
 ```shellsession
 $ /usr/local/bin/synology-letsencrypt.sh -p /usr/local/bin/synology-letsencrypt/example.com

--- a/README.md
+++ b/README.md
@@ -37,6 +37,24 @@ To schedule a daily task, log into the Synology DSM and add a user-defined scrip
           General -> User = root
           Task Settings -> User-defined script = /usr/local/bin/synology-letsencrypt.sh
 
+### Multiple Certificates
+
+If you need to generate more than one certificate with this, you can parameterize synology-letsencrypt.sh with the name of a certificate configuration:
+
+```shellsession
+$ /usr/local/bin/synology-letsencrypt.sh example.com
+$ /usr/local/bin/synology-letsencrypt.sh other-example.com
+```
+
+This creates an entire configuration in
+`/usr/local/etc/synology-letsencrypt/example.com/env` and
+`/usr/local/etc/synology-letsencrypt/other-example.com/env` respectively, which
+you can tune according to your needs. That extends to modifying the `hook` in
+each one to match your needs.
+
+You might want this if you require more than one certificate on the Synology, or
+if you want to generate a certificate for another host on your Synology.
+
 ## Uninstall
 
 To **uninstall** synology-letsencrypt, run the [uninstall script](uninstall.sh). To do that, either download and run the script manually, or use the following cURL command:

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ To schedule a daily task, log into the Synology DSM and add a user-defined scrip
 
 ### Multiple Certificates
 
-If you need to generate more than one certificate with this, you can parameterize synology-letsencrypt.sh with the name of a certificate configuration:
+If you need to generate more than one certificate with this, you can parameterize synology-letsencrypt.sh with the path of a certificate configuration:
 
 ```shellsession
-$ /usr/local/bin/synology-letsencrypt.sh example.com
-$ /usr/local/bin/synology-letsencrypt.sh other-example.com
+$ /usr/local/bin/synology-letsencrypt.sh -p /usr/local/bin/synology-letsencrypt/example.com
+$ /usr/local/bin/synology-letsencrypt.sh -p /usr/local/bin/synology-letsencrypt/other-example.com
 ```
 
 This creates an entire configuration in
@@ -54,6 +54,15 @@ each one to match your needs.
 
 You might want this if you require more than one certificate on the Synology, or
 if you want to generate a certificate for another host on your Synology.
+
+### Customizing the hook script
+
+By default, `synology-letsencrypt.sh` will overwrite any changes you make to the
+hook script to preserve the core functionality of this client. If you have customized your script, you can preserve its changes by adding the `-c` parameter to your invocation:
+
+```shellsession
+$ /usr/local/bin/synology-letsencrypt.sh -c
+```
 
 ## Uninstall
 

--- a/synology-letsencrypt.sh
+++ b/synology-letsencrypt.sh
@@ -18,26 +18,26 @@ if [[ ! -s $cert_id_path ]]; then
 fi
 source "$cert_id_path"
 
-
-## install hook
+## install hook if necessary
 archive_path="/usr/syno/etc/certificate/_archive/$cert_id"
 if [[ ! -d $archive_path ]]; then
     mkdir -p "$archive_path"
 fi
 
-cat > "$hook_path" <<EOF
-#!/bin/bash
+if [[ ! -x $hook_path ]]; then
+    cat >"$hook_path" <<EOF
+   #!/bin/bash
 
-cp  $cert_path/$cert_domain.crt "$archive_path/cert.pem"
-cp  $cert_path/$cert_domain.issuer.crt "$archive_path/chain.pem"
-cat $cert_path/$cert_domain.crt $cert_path/$cert_domain.issuer.crt > $archive_path/fullchain.pem
-cp  $cert_path/$cert_domain.key $archive_path/privkey.pem
+   cp  $cert_path/$cert_domain.crt "$archive_path/cert.pem"
+   cp  $cert_path/$cert_domain.issuer.crt "$archive_path/chain.pem"
+   cat $cert_path/$cert_domain.crt $cert_path/$cert_domain.issuer.crt > $archive_path/fullchain.pem
+   cp  $cert_path/$cert_domain.key $archive_path/privkey.pem
 
-/usr/local/bin/synology-letsencrypt-reload-services.sh "$cert_id"
+   /usr/local/bin/synology-letsencrypt-reload-services.sh "$cert_id"
 EOF
 
-chmod 700 "$hook_path"
-
+    chmod 700 "$hook_path"
+fi
 
 ## run or renew
 if [[ -s $cert_path/$cert_domain.crt ]]; then

--- a/synology-letsencrypt.sh
+++ b/synology-letsencrypt.sh
@@ -11,7 +11,7 @@ while getopts ":p:ch" opt; do
             exit 0
             ;;
         :) echo "Error: -${OPTARG} requires an argument" >&2 ;;
-        \?) echo "Invalid iotion -$OPTARG" >&2 ;;
+        \?) echo "Invalid option -$OPTARG" >&2 ;;
     esac
 done
 
@@ -71,6 +71,5 @@ fi
     --key-type "rsa4096" \
     --email "$EMAIL" \
     --dns "$DNS_PROVIDER" \
-    --dns.resolvers=8.8.8.8,8.8.4.4 \
     "${DOMAINS[@]}" \
     "${CMD[@]}" "$hook_path"

--- a/synology-letsencrypt.sh
+++ b/synology-letsencrypt.sh
@@ -1,8 +1,12 @@
 #!/bin/bash -e
 
 [[ $EUID == 0 ]] || { echo >&2 "This script must be run as root"; exit 1; }
+if [[ "${1:-xxx}" == "xxx" ]]; then
+    export LEGO_PATH="/usr/local/etc/synology-letsencrypt"
+else
+    export LEGO_PATH="/usr/local/etc/synology-letsencrypt/${1}"
+fi
 
-export LEGO_PATH="/usr/local/etc/synology-letsencrypt"
 source "$LEGO_PATH/env"
 
 cert_path="$LEGO_PATH/certificates"

--- a/synology-letsencrypt.sh
+++ b/synology-letsencrypt.sh
@@ -1,11 +1,27 @@
 #!/bin/bash -e
 
-[[ $EUID == 0 ]] || { echo >&2 "This script must be run as root"; exit 1; }
-if [[ "${1:-xxx}" == "xxx" ]]; then
-    export LEGO_PATH="/usr/local/etc/synology-letsencrypt"
-else
-    export LEGO_PATH="/usr/local/etc/synology-letsencrypt/${1}"
-fi
+while getopts ":p:ch" opt; do
+    case $opt in
+        p) LEGO_PATH="$OPTARG" ;;
+        c) CREATE_HOOK=false ;;
+        h)
+            echo "Usage: $0 [options]"
+            echo "  -p <lego_path> The path where Lego will install your certs"
+            echo "  -c Suppress [c]reation of the hook scripts, if you have your own"
+            exit 0
+            ;;
+        :) echo "Error: -${OPTARG} requires an argument" >&2 ;;
+        \?) echo "Invalid iotion -$OPTARG" >&2 ;;
+    esac
+done
+
+LEGO_PATH=${LEGO_PATH:-/usr/local/etc/synology-letsencrypt}
+CREATE_HOOK=${CREATE_HOOK:-true}
+
+[[ $EUID == 0 ]] || {
+    echo >&2 "This script must be run as root"
+    exit 1
+}
 
 source "$LEGO_PATH/env"
 
@@ -13,31 +29,30 @@ cert_path="$LEGO_PATH/certificates"
 cert_domain="${DOMAINS[1]#\*.}"
 hook_path="$LEGO_PATH/hook"
 
-
 ## cert_id
 cert_id_path="$cert_path/$cert_domain.cert_id"
 if [[ ! -s $cert_id_path ]]; then
     mkdir -p "$cert_path"
-    /usr/local/bin/synology-letsencrypt-make-cert-id.sh > "$cert_id_path"
+    /usr/local/bin/synology-letsencrypt-make-cert-id.sh >"$cert_id_path"
 fi
 source "$cert_id_path"
 
-## install hook if necessary
+## install hook
 archive_path="/usr/syno/etc/certificate/_archive/$cert_id"
 if [[ ! -d $archive_path ]]; then
     mkdir -p "$archive_path"
 fi
 
-if [[ ! -x $hook_path ]]; then
+if [[ ${CREATE_HOOK} == true ]]; then
     cat >"$hook_path" <<EOF
-   #!/bin/bash
+#!/bin/bash
 
-   cp  $cert_path/$cert_domain.crt "$archive_path/cert.pem"
-   cp  $cert_path/$cert_domain.issuer.crt "$archive_path/chain.pem"
-   cat $cert_path/$cert_domain.crt $cert_path/$cert_domain.issuer.crt > $archive_path/fullchain.pem
-   cp  $cert_path/$cert_domain.key $archive_path/privkey.pem
+cp  $cert_path/$cert_domain.crt "$archive_path/cert.pem"
+cp  $cert_path/$cert_domain.issuer.crt "$archive_path/chain.pem"
+cat $cert_path/$cert_domain.crt $cert_path/$cert_domain.issuer.crt > $archive_path/fullchain.pem
+cp  $cert_path/$cert_domain.key $archive_path/privkey.pem
 
-   /usr/local/bin/synology-letsencrypt-reload-services.sh "$cert_id"
+/usr/local/bin/synology-letsencrypt-reload-services.sh "$cert_id"
 EOF
 
     chmod 700 "$hook_path"
@@ -56,7 +71,6 @@ fi
     --key-type "rsa4096" \
     --email "$EMAIL" \
     --dns "$DNS_PROVIDER" \
+    --dns.resolvers=8.8.8.8,8.8.4.4 \
     "${DOMAINS[@]}" \
     "${CMD[@]}" "$hook_path"
-
-


### PR DESCRIPTION
I had some specialized needs:

* I wanted to customize the hook and have it retained, instead of overwritten, so I made that conditional
* I am generating certificates for other network hardware on my synology, so I added support for running this with different certificate configuration