### PR TITLE
Reload DirectoryServer if it is running

### DIFF
--- a/synology-letsencrypt-reload-services.sh
+++ b/synology-letsencrypt-reload-services.sh
@@ -72,8 +72,19 @@ reload_nginx() {
     fi
 }
 
+reload_package() {
+    local package_name="$1"
+    if [[ -x /usr/syno/bin/synopkg ]]; then
+        if /usr/syno/bin/synopkg status "$package_name" | grep -q '"status":"running"'; then
+            /usr/syno/bin/synopkg restart "$package_name"
+        else
+            echo "Package $package_name is not running" >&2
+        fi
+    else
+        echo "synopkg not found" >&2
+    fi
+}
 
 reload_services
 reload_nginx
-
-
+reload_package DirectoryServer


### PR DESCRIPTION
If the DirectoryServer is running it restarts so the new certs are picked up.

Fixes https://github.com/JessThrysoee/synology-letsencrypt/issues/20. This allows us to correctly bind to the LDAP server instead of getting cert issue.

I have added a generic function so in future more packages can be restarted if necessary.