### PR TITLE
generate fullchain cert

### DIFF
--- a/synology-letsencrypt.sh
+++ b/synology-letsencrypt.sh
@@ -51,7 +51,8 @@ if [[ ${CREATE_HOOK} == true ]]; then
 
 cp  $cert_path/$cert_domain.crt "$archive_path/cert.pem"
 cp  $cert_path/$cert_domain.issuer.crt "$archive_path/chain.pem"
-cat $cert_path/$cert_domain.crt $cert_path/$cert_domain.issuer.crt > $archive_path/fullchain.pem
+cat $cert_path/$cert_domain.crt $cert_path/$cert_domain.issuer.crt > $cert_path/$cert_domain.fullchain.crt
+cp  $cert_path/$cert_domain.fullchain.crt > $archive_path/fullchain.pem
 cp  $cert_path/$cert_domain.key $archive_path/privkey.pem
 
 /usr/local/bin/synology-letsencrypt-reload-services.sh "$cert_id"


### PR DESCRIPTION
Fixes https://github.com/JessThrysoee/synology-letsencrypt/issues/22

This generates fullchain cert in $cert_path so that it can be used in traefik. While $archive_path contains the fullchain.pem it is hard to locate this directory as it contains id and can be hard to use in dockers compose. Having fullchain cert generate in $cert_path means I can now have a easy to use path such as `/usr/local/etc/synology-letsencrypt/example.com/certificates/example.com.fullchain.crt`