### PR TITLE
Allow to reload all services attached to all certificate

### DIFF
--- a/synology-letsencrypt-reload-services.sh
+++ b/synology-letsencrypt-reload-services.sh
@@ -75,5 +75,11 @@ reload_services() {
     done
 }
 
-reload_services
-
+if [[ -z $CERT_ID ]]; then
+    for c_id in $(jq -r 'keys[]' $INFO); do
+        CERT_ID=$c_id
+        reload_services
+    done
+else
+    reload_services
+fi


### PR DESCRIPTION
if synology-letsencrypt-reload-services.sh script is launched without first parameter, which should be the cert_id,
it will loop for all certificates and reload attached services and update certificate

It may allow one to use this script independently without previsously have created a cert id with synology-letsencrypt-reload-services.sh but with other method (I personnaly use acme in docker, and i use this forked script outside of docker to reload services)