### PR TITLE
Syntax Fix to Lego Cert generation on wildcards

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -50,7 +50,7 @@ install_script() {
     local name="$1"
     local path="/usr/local/bin/$name"
 
-    sudo curl -sSL -o "$path" "https://raw.githubusercontent.com/dpbattaglia-gps/synology-letsencrypt/master/$name"
+    sudo curl -sSL -o "$path" "https://raw.githubusercontent.com/JessThrysoee/synology-letsencrypt/master/$name"
 
     permissions 755 "$path"
     printf "installed: %s\n" "$path"

--- a/install.sh
+++ b/install.sh
@@ -50,7 +50,7 @@ install_script() {
     local name="$1"
     local path="/usr/local/bin/$name"
 
-    sudo curl -sSL -o "$path" "https://raw.githubusercontent.com/JessThrysoee/synology-letsencrypt/master/$name"
+    sudo curl -sSL -o "$path" "https://raw.githubusercontent.com/dpbattaglia-gps/synology-letsencrypt/master/$name"
 
     permissions 755 "$path"
     printf "installed: %s\n" "$path"

--- a/synology-letsencrypt.sh
+++ b/synology-letsencrypt.sh
@@ -26,7 +26,7 @@ export LEGO_PATH
 
 archive_path="/usr/syno/etc/certificate/_archive"
 cert_path="$LEGO_PATH/certificates"
-cert_domain="${DOMAINS[1]#\*.}"
+cert_domain=$(basename "$(ls "$cert_path"/*.key)" .key)
 hook_path="$LEGO_PATH/hook"
 mkdir -p "$cert_path"
 


### PR DESCRIPTION
Essentially LEGO has changed the way it supports wildcards now with  "_"

Proposed fix handles that usecase